### PR TITLE
validation: Add validation results for tested libraries.

### DIFF
--- a/librarylist.yaml
+++ b/librarylist.yaml
@@ -1,95 +1,96 @@
+---
 libraries:
-- micropython-rotary:
+  - micropython-rotary:
     name: MicroPython Rotary Encoder Driver
     url: https://github.com/miketeachman/micropython-rotary
-    author: miketeachman 
+    author: miketeachman
     description: MicroPython driver to read a rotary encoder. Works with Pyboard, Raspberry Pi Pico, ESP8266, and ESP32 development boards. This is a robust implementation providing effective debouncing of encoder contacts. It uses two GPIO pins configured to trigger interrupts, ...
-    tags: [ "encoder" ]
+    tags: ["encoder"]
     verification:
-        - fqbn: "arduino:mbed_nano:nanorp2040connect"
-          library_version: null
-          micropython_version: "1.19.1"
-          tester: "arduino"
-- lcd:
+      - fqbn: "arduino:mbed_nano:nanorp2040connect"
+        library_version: null
+        micropython_version: "1.19.1"
+        tester: "arduino"
+  - lcd:
     name: lcd_api and i2c_lcd
     url: https://github.com/dhylands/python_lcd/
     description: Python code for talking to HD44780 compatible character based dot matrix LCDs.
     license: MIT license; Copyright (c) 2013 Dave Hylands
-    tags: [ "display", "LCD" ]
-- picoservo:
+    tags: ["display", "LCD"]
+  - picoservo:
     name: Picoservo
     url: https://github.com/sandbo00/picoservo
     description: A simple class for controlling a 9g servo with the Raspberry Pi Pico.
-    tags: [ "servo" ]
-- micropython-DS3231-AT24C32:
+    tags: ["servo"]
+  - micropython-DS3231-AT24C32:
     name: MicroPython driver for DS3231 RTC and AT24C32 EEPROM module.
     url: https://github.com/pangopi/micropython-DS3231-AT24C32
     description: MicroPython driver for DS3231 RTC and AT24C32 EEPROM module.
-    tags: [ "time", "RTC" ]
-- micropython_ahtx0:
+    tags: ["time", "RTC"]
+  - micropython_ahtx0:
     name: AHT10 and AHT20 temperature and humidity sensors
     url: https://github.com/targetblank/micropython_ahtx0
     description: MicroPython driver for the AHT10 and AHT20 temperature and humidity sensors.
-    tags: [ "sensors", "temperature", "humidity" ]
-- micropython-dfplayer:
+    tags: ["sensors", "temperature", "humidity"]
+  - micropython-dfplayer:
     name: DFPlayer control using UART 1
     url: https://github.com/ubidefeo/micropython-dfplayer
     description: Micropython implementation of DFPlayer control over UART
-    tags: [ "audio", "mp3" ] 
+    tags: ["audio", "mp3"]
     verification:
-        - fqbn: "arduino:mbed_nano:nanorp2040connect"
-          library_version: null
-          micropython_version: "1.19.1"
-          tester: "arduino"
--  MAX30102-MicroPython-driver: 
+      - fqbn: "arduino:mbed_nano:nanorp2040connect"
+        library_version: null
+        micropython_version: "1.19.1"
+        tester: "arduino"
+  - MAX30102-MicroPython-driver:
     name: Maxim MAX30102 MicroPython driver
     url: https://github.com/n-elia/MAX30102-MicroPython-driver
     description: A port of the SparkFun driver for Maxim MAX30102 sensor to MicroPython.
-    tags: [ "sensors" ]
-- micropython-i2c-lcd: 
+    tags: ["sensors"]
+  - micropython-i2c-lcd:
     name: MicroPython I2C 16x2 LCD Screen (monochrome and RGB)
     url: https://github.com/ubidefeo/micropython-i2c-lcd
     description: This library is designed to support a MicroPython interface for i2c LCD character screens. It is designed around the Pycom implementation of MicroPython
-    tags: [ "display", "LCD", "RGB" ]
-- sh1107-micropython:
+    tags: ["display", "LCD", "RGB"]
+  - sh1107-micropython:
     name: SH1107 based OLED display
     url: https://github.com/nemart69/sh1107-micropython
     description: Micropython driver for SH1107-based OLED display (64 x 128)
-    tags: [ "display", "OLED" ]
-- pi_pico_neopixel:
+    tags: ["display", "OLED"]
+  - pi_pico_neopixel:
     name: Library for Raspberry Pi Pico
-    url: https://github.com/blaz-r/pi_pico_neopixel 
+    url: https://github.com/blaz-r/pi_pico_neopixel
     description: a library for using ws2812b and sk6812 leds (aka neopixels) with Raspberry Pi Pico
-    tags: [ "LED" ]
-- micropython-thermal-printer:
+    tags: ["LED"]
+  - micropython-thermal-printer:
     name: MicroPython Thermal Printer
-    url: https://github.com/ayoy/micropython-thermal-printer 
+    url: https://github.com/ayoy/micropython-thermal-printer
     description: This is the MicroPython port of Python Thermal Printer by Adafruit
-    tags: [ "printer" ]
-- micropython-tm1637:
+    tags: ["printer"]
+  - micropython-tm1637:
     name: MicroPython TM1637
     url: https://github.com/mcauser/micropython-tm1637
     description: A MicroPython library for quad 7-segment LED display modules using the TM1637 LED driver. For example, the Grove - 4 Digit Display module http://wiki.seeed.cc/Grove-4-Digit_Display/
-    tags: [ "display" ]
+    tags: ["display"]
     verification:
-        - fqbn: "arduino:mbed_nano:nanorp2040connect"
-          library_version: "1.3.0"
-          micropython_version: "1.19.1"
-          tester: "arduino"
-- micropython-max7219:
+      - fqbn: "arduino:mbed_nano:nanorp2040connect"
+        library_version: "1.3.0"
+        micropython_version: "1.19.1"
+        tester: "arduino"
+  - micropython-max7219:
     name: MicroPython MAX7219 8x8 LED Matrix
     url: https://github.com/mcauser/micropython-max7219
     description: A MicroPython library for the MAX7219 8x8 LED matrix driver, SPI interface, supports cascading and uses framebuf
-    tags: [ "LED", "matrix" ]
+    tags: ["LED", "matrix"]
     license: Licensed under the MIT License.
-- micropython-PressureTemp:
+  - micropython-PressureTemp:
     name: Pressure/temp sensor
     url: https://github.com/RuiSantosdotme/ESP-MicroPython
-    description:  Adafruit BME280 Library, a library for the Adafruit BME280 Humidity, Barometric Pressure + Temp sensor.
-    tags: [ "pressure", "temperature" ]
-- micropython-IR:
+    description: Adafruit BME280 Library, a library for the Adafruit BME280 Humidity, Barometric Pressure + Temp sensor.
+    tags: ["pressure", "temperature"]
+  - micropython-IR:
     name: Device drivers for IR (infra red) remote controls
     url: https://github.com/peterhinch/micropython_ir
-    description:   Device drivers for IR (infra red) remote controls
+    description: Device drivers for IR (infra red) remote controls
     license: This repo provides a driver to receive from IR (infra red) remote controls and a driver for IR "blaster" apps.
-    tags: [ "IR" ]
+    tags: ["IR"]


### PR DESCRIPTION
I added a verification tag for the tested libraries already in the registry. I was thinking a bit about how to make this reliable, and I think we need to specify which version of the library was tested with which version of MicroPython with which board. Only then we can guarantee that this specific setup works. We probably need to allow multiple verifications for each board because it's not guaranteed that e.g. a newer version of MicroPython still works with an older (but tested) version of the library. I'm suggesting the following syntax:

```
    verification:
        - fqbn: "arduino:mbed_nano:nanorp2040connect"
          library_version: "1.2.1"
          micropython_version: "1.19.1"
          tester: "arduino"
```

This is quite restrictive but would allow to issue warning messages in a future scenario in which the installation tool could report `The version of 'df-player' that you're trying to install is newer than the last verified one and may not be compatible with the 'Arduino Nano RP2040 Connect'. Do you want to proceed?`
The library on the other hand may require features or fixes that are not available in older versions of MicroPython and the tool could also print a warning accordingly:
`The MicroPython version on 'Arduino Nano RP2040 Connect' is older than the last verified one for this library and may not be compatible. Do you want to proceed?`
Or `The version of 'df-player' that you're trying to install has been tested on an older version of MicroPython and may not be compatible with your version. Do you want to proceed?`
We can follow the semantic versioning approach and basically say if the version differs only on the patch level it can be treated as compatible.

Then I would open up the verification to the community as discussed and hence add a "tester" field to specify if we tested it internally or if someone from the community did. I think allowing to use a Github username there can be more useful than `community_verified` so that we could get back to that person if necessary.

Please share your thoughts on the approach mentioned in this PR.