### PR TITLE
Fix data structure of "Render Registry" workflow

### DIFF
--- a/.github/workflows/render-registry.yml
+++ b/.github/workflows/render-registry.yml
@@ -1,8 +1,8 @@
 name: Render Registry
 on: 
-  - push
-  branches:
-    - main
+  push:
+    branches:
+      - main
 jobs:
   render:
     runs-on: ubuntu-latest


### PR DESCRIPTION
An invalid data structure of "Render Registry" GitHub Actions workflow caused a spurious failure of the workflow runs:

https://github.com/arduino/package-index-py/actions/runs/5546843762

> Invalid workflow file: .github/workflows/render-registry.yml#L2
> You have an error in your yaml syntax on line 2

In this usage, both the [`on`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on) and [`push`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore) keys must be [mappings](https://yaml.org/spec/1.2.2/ext/glossary/#mapping) (AKA objects).