### PR TITLE
Add new packages to support basic hardware components

### DIFF
--- a/package-list.yaml
+++ b/package-list.yaml
@@ -74,6 +74,9 @@ packages:
     url: https://github.com/sandbo00/picoservo
     description: A simple class for controlling a 9g servo with the Raspberry Pi Pico.
     tags: ["servo"]
+    package_descriptor:
+      urls:
+        - [servo.py, github:sandbo00/picoservo/servo.py]
   - name: micropython-DS3231-AT24C32
     url: https://github.com/pangopi/micropython-DS3231-AT24C32
     description: MicroPython driver for DS3231 RTC and AT24C32 EEPROM module.
@@ -99,10 +102,29 @@ packages:
     url: https://github.com/ubidefeo/micropython-i2c-lcd
     description: This library is designed to support a MicroPython interface for i2c LCD character screens. It is designed around the Pycom implementation of MicroPython
     tags: ["display", "LCD", "RGB"]
+  - name: micropython-i2c-lcd-monochrome
+    url: https://github.com/brainelectronics/micropython-i2c-lcd
+    description: Micropython package to control HD44780 LCD displays 1602 and 2004 via I2C
+    license: MIT
   - name: sh1107-micropython
     url: https://github.com/nemart69/sh1107-micropython
     description: Micropython driver for SH1107-based OLED display (64 x 128)
     tags: ["display", "OLED"]
+  - name: SH1106
+    url: https://github.com/robert-hh/SH1106
+    description: MicroPython driver for the SH1106 OLED controller
+    tags: ["display", "OLED"]
+    package_descriptor:
+      urls:
+        - [sh1106.py, github:robert-hh/SH1106/sh1106.py]
+  - name: ir_rx
+    url: https://github.com/peterhinch/micropython_ir/ir_rx
+    description: A MicroPython driver for IR (infra red) remote controls receivers
+    tags: ["IR"]
+  - name: ir_tx
+    url: https://github.com/peterhinch/micropython_ir/ir_tx
+    description: A MicroPython driver for IR (infra red) remote controls transmitters
+    tags: ["IR"]
   - name: pi_pico_neopixel
     url: https://github.com/blaz-r/pi_pico_neopixel
     description: a library for using ws2812b and sk6812 leds (aka neopixels) with Raspberry Pi Pico


### PR DESCRIPTION
Add support for:

- Servos
- 1602 Monochrome LCD
- SH1106 OLED
- Infrared receiver
- Infrared transmitter